### PR TITLE
Disable availability date unless manual is selected

### DIFF
--- a/frontend/src/components/Schedule/Schedule.tsx
+++ b/frontend/src/components/Schedule/Schedule.tsx
@@ -21,6 +21,7 @@ import CaptureQualityField from '../forms/fields/CaptureQualityField'
 import EndTimeField from '../forms/fields/EndTimeField'
 import GroupSelectField from '../forms/fields/GroupSelectField'
 // import LiveStreamField from '../forms/fields/LiveStreamField'
+import AvailabilityCard from '../forms/fields/AvailabilityCard'
 import PresenterField from '../forms/fields/PresenterField'
 import RecordingDateField from '../forms/fields/RecordingDateField'
 import RequestedByField from '../forms/fields/RequestedByField'
@@ -95,16 +96,7 @@ const Schedule: React.FC = () => {
                            </div>
                         </div>
                         <div className="availability border rounded-lg p-3 mb-3">
-                           <div className="flex flex-col lg:flex-row justify-between gap-4">
-                              <div className="select-availability gap-3 mx-3">
-                                 {/* switch */}                      
-                                 <AvailabilityField />
-                              </div>
-                              <div className="availability-date gap-3 mr-16">
-                                 {/* datepicker if set to manual */}
-                                <AvailabilityDateField />
-                              </div>
-                           </div>
+                           <AvailabilityCard />
                         </div>
                         {/* <div className="live-stream border rounded-lg p-3 mb-3">
                            <div className="flex flex-col lg:flex-row justify-between gap-3 px-3 pt-2 pb-3">

--- a/frontend/src/components/forms/fields/AvailabilityCard.tsx
+++ b/frontend/src/components/forms/fields/AvailabilityCard.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import AvailabilityDateField from './AvailabilityDateField';
+import AvailabilityField from './AvailabilityField';
+
+const AvailabilityCard: React.FC = () => {
+   const [availability, setAvailability] = React.useState<string>("");
+   const [isVisible, setIsVisible] = React.useState<boolean>(false);
+   const forms = useFormContext();
+   const field = forms.watch("availability");
+
+   React.useEffect(()=>{
+      setAvailability(forms.getValues("availability"));
+
+   }, [field, forms]);
+
+   React.useEffect(()=>{
+      if (availability == "Manual") {
+         setIsVisible(true);
+      } else {
+         setIsVisible(false);
+      }
+   }, [availability])
+
+  return (
+   <div className="flex flex-col lg:flex-row justify-between gap-4">
+      <div className="select-availability gap-3 mx-3">                 
+         <AvailabilityField />
+      </div>
+      <div className="availability-date gap-3 mr-16">
+         {/* unlock datepicker if availability set to manual */}
+         <AvailabilityDateField disabled={!isVisible}/>
+         
+      </div>
+   </div>
+  )
+}
+
+export default AvailabilityCard

--- a/frontend/src/components/forms/fields/AvailabilityDateField.tsx
+++ b/frontend/src/components/forms/fields/AvailabilityDateField.tsx
@@ -8,11 +8,16 @@ import { CalendarIcon } from 'lucide-react';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
+interface Props {
+   disabled: boolean;
+}
 
+const AvailabilityDateField: React.FC<Props> = (props: Props) => {
+   const { disabled } = props;
 
-const AvailabilityDateField: React.FC = () => {
    const form = useFormContext();
-  return (
+
+   return (
       <FormField
          control={form.control}
          name="availability_date"
@@ -24,6 +29,7 @@ const AvailabilityDateField: React.FC = () => {
                      <FormControl>
                         <Button
                            variant={"outline"}
+                           disabled={disabled}
                            className={cn(
                               "w-[240px] pl-3 text-left font-normal",
                               !field.value && "text-muted-foreground"

--- a/frontend/src/components/forms/fields/AvailabilityField.tsx
+++ b/frontend/src/components/forms/fields/AvailabilityField.tsx
@@ -11,7 +11,6 @@ import { Check, ChevronsUpDown } from "lucide-react";
 import { useFormContext } from "react-hook-form";
 
 
-
 const AvailabilityField: React.FC = () => {
    const form = useFormContext();
   return (
@@ -47,6 +46,7 @@ const AvailabilityField: React.FC = () => {
                            value={availability.label}
                            onSelect={() => {
                               form.setValue("availability", availability.value);
+                              
                            }}
                         >
                            <Check


### PR DESCRIPTION
Disables the 'Availability Date' field from the schedule a recording form unless user selects 'Manual' from the availability dropdown field.